### PR TITLE
Fix Algolia elixir sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,24 @@ brew install elixir
 ## Run
 
 ```sh
-APPID= APIKEY= INDEXNAME= mix run
+APPID= APIKEY= INDEXNAME= iex -S mix
 ```
 
-## Result
-
-```txt
-Compiling 1 file (.ex)
-
-== Compilation error in file lib/test.ex ==
-** (Protocol.UndefinedError) protocol String.Chars not implemented for {:query, "batman"}
-    (elixir) lib/string/chars.ex:3: String.Chars.impl_for!/1
-    (elixir) lib/string/chars.ex:22: String.Chars.to_string/1
-    (elixir) lib/enum.ex:1940: Enum."-join/2-lists^foldl/2-0-"/3
-    (elixir) lib/enum.ex:1940: Enum.join/2
-    lib/algolia/paths.ex:60: Algolia.Paths.encode_param/1
-    (elixir) lib/enum.ex:1327: Enum."-map/2-lists^map/1-0-"/2
-    lib/algolia/paths.ex:56: Algolia.Paths.build_query/1
-    lib/algolia/paths.ex:52: Algolia.Paths.to_query/1
+```elixir
+Interactive Elixir (1.8.1) - press Ctrl+C to exit (type h() ENTER for help)
+iex(1)> Test.hello
+{:ok,
+ %{
+   "exhaustiveNbHits" => true,
+   "hits" => [
+     # ...
+   ],
+   "hitsPerPage" => 20,
+   "nbHits" => 1,
+   "nbPages" => 1,
+   "page" => 0,
+   "params" => "query=batman",
+   "processingTimeMS" => 1,
+   "query" => "batman"
+ }}
 ```
-
-

--- a/lib/test.ex
+++ b/lib/test.ex
@@ -14,8 +14,6 @@ defmodule Test do
 
   """
   def hello do
-    Algolia.search(System.get_env("INDEXNAME"), [query: "batman"])
+    Algolia.search(System.get_env("INDEXNAME"), "batman")
   end
 end
-
-Test.hello()


### PR DESCRIPTION
Closes https://github.com/sikanhe/algolia-elixir/issues/30

Hi @vvo, here is a working sample of the Algolia Elixir library. I basically made two changes:

- Update `Algolia.search/2` function call to use the correct parameters.
- Remove the autorun command `Test.hello()` so it is easier to test using the Elixir console `iex -S mix`

If you want to keep the autorun version you will need to make some changes to the code to ensure hackney is started and also to print the result in the console. Something like that should work:

```elixir
{:ok, _apps} = Application.ensure_all_started(:hackney)
Test.hello() |> IO.inspect()
```

Let me know if you need any other help using the library. Happy to work together with Algolia team to make it an official library.